### PR TITLE
Fix computing video view's width and height when using padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ And that's all. Now you have `window.RTCPeerConnection`, `navigator.getUserMedia
 
 **Q:** What about `<video>` elements and `video.src = URL.createObjectURL(stream)`? do I need custom HTML tags or functions to display WebRTC videos?
 
-**R:** No. Just use an HTML video element as usual, really. The plugin will properly place a native *UIView* layer on top of it by respecting (most of) its [CSS properties](videoCSS.md).
+**R:** No. Just use an HTML video element as usual, really. The plugin will properly place a native *UIView* layer on top of it by respecting (most of) its [CSS properties](docs/videoCSS.md).
 
 **Q:** Can I place HTML elements (buttons and so on) on top of active `<video>` elements?
 

--- a/dist/cordova-plugin-iosrtc.js
+++ b/dist/cordova-plugin-iosrtc.js
@@ -579,17 +579,38 @@ MediaStreamRenderer.prototype.refresh = function () {
 		elementTop = elementPositionAndSize.top,
 		elementWidth = elementPositionAndSize.width,
 		elementHeight = elementPositionAndSize.height,
-		videoViewWidth = elementWidth,
-		videoViewHeight = elementHeight,
+		videoViewWidth,
+		videoViewHeight,
 		visible,
 		opacity,
 		zIndex,
 		mirrored,
 		objectFit,
 		clip,
-		borderRadius;
+		borderRadius,
+		paddingTop,
+		paddingBottom,
+		paddingLeft,
+		paddingRight;
 
 	computedStyle = window.getComputedStyle(this.element);
+
+	// get padding values
+	paddingTop = parseInt(computedStyle.paddingTop)|0;
+	paddingBottom = parseInt(computedStyle.paddingBottom)|0;
+	paddingLeft = parseInt(computedStyle.paddingLeft)|0;
+	paddingRight = parseInt(computedStyle.paddingRight)|0;
+
+	// fix position according to padding
+	elementLeft += paddingLeft;
+	elementTop += paddingTop;
+
+	// fix width and height according to padding
+	elementWidth -= (paddingLeft + paddingRight);
+	elementHeight -= (paddingTop + paddingBottom);
+
+	videoViewWidth = elementWidth;
+	videoViewHeight = elementHeight;
 
 	// visible
 	if (computedStyle.visibility === 'hidden') {

--- a/docs/videoCSS.md
+++ b/docs/videoCSS.md
@@ -9,6 +9,7 @@ Supported CSS properties are:
 * `display`
 * `opacity`
 * `visibility`
+* `padding`
 * `z-index`: Useful to place a video on top of another video.
 * [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)
 * `-webkit-transform: scaleX(-1)`: Useful for horizontal mirror effect.

--- a/js/MediaStreamRenderer.js
+++ b/js/MediaStreamRenderer.js
@@ -116,17 +116,38 @@ MediaStreamRenderer.prototype.refresh = function () {
 		elementTop = elementPositionAndSize.top,
 		elementWidth = elementPositionAndSize.width,
 		elementHeight = elementPositionAndSize.height,
-		videoViewWidth = elementWidth,
-		videoViewHeight = elementHeight,
+		videoViewWidth,
+		videoViewHeight,
 		visible,
 		opacity,
 		zIndex,
 		mirrored,
 		objectFit,
 		clip,
-		borderRadius;
+		borderRadius,
+		paddingTop,
+		paddingBottom,
+		paddingLeft,
+		paddingRight;
 
 	computedStyle = window.getComputedStyle(this.element);
+
+	// get padding values
+	paddingTop = parseInt(computedStyle.paddingTop)|0;
+	paddingBottom = parseInt(computedStyle.paddingBottom)|0;
+	paddingLeft = parseInt(computedStyle.paddingLeft)|0;
+	paddingRight = parseInt(computedStyle.paddingRight)|0;
+
+	// fix position according to padding
+	elementLeft += paddingLeft;
+	elementTop += paddingTop;
+
+	// fix width and height according to padding
+	elementWidth -= (paddingLeft + paddingRight);
+	elementHeight -= (paddingTop + paddingBottom);
+
+	videoViewWidth = elementWidth;
+	videoViewHeight = elementHeight;
 
 	// visible
 	if (computedStyle.visibility === 'hidden') {


### PR DESCRIPTION
According to [the MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Element/clientWidth) the padding is included, so substract it.