### PR TITLE
Fix for z-index / transparent background / stacking of UIViews issue

### DIFF
--- a/extra/hooks/iosrtc-swift-support.js
+++ b/extra/hooks/iosrtc-swift-support.js
@@ -57,6 +57,7 @@ module.exports = function (context) {
 		xcconfigPath = path.join(projectRoot, '/platforms/ios/cordova/build.xcconfig'),
 		xcodeProjectName = projectName + '.xcodeproj',
 		xcodeProjectPath = path.join(projectRoot, 'platforms', 'ios', xcodeProjectName, 'project.pbxproj'),
+		MainViewControllerPath = path.join(projectRoot, 'platforms', 'ios', projectName, 'Classes', 'MainViewController.m'),
 		swiftBridgingHead = projectName + BRIDGING_HEADER_END,
 		swiftBridgingHeadXcode = '"' + swiftBridgingHead + '"',
 		swiftOptions = [''], // <-- begin to file appending AFTER initial newline
@@ -98,6 +99,13 @@ module.exports = function (context) {
 	// swiftOptions.push('EMBEDDED_CONTENT_CONTAINS_SWIFT = YES');
 	fs.appendFileSync(xcconfigPath, swiftOptions.join('\n'));
 	debug('file correctly fixed: ' + xcconfigPath);
+
+	var result = fs.readFileSync(MainViewControllerPath, 'utf8')
+	var rep ='theWebView.backgroundColor = [UIColor blackColor];';
+	result = result.replace('theWebView.backgroundColor = [UIColor blackColor];', 'theWebView.opaque = NO;');
+  fs.writeFileSync(MainViewControllerPath, result, 'utf8');
+	debug('MainViewController.m correctly fixed: ' + xcconfigPath);
+
 
 	// "project.pbxproj"
 	// Parsing it

--- a/src/PluginMediaStreamRenderer.swift
+++ b/src/PluginMediaStreamRenderer.swift
@@ -20,6 +20,8 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 
 		// The browser HTML view.
 		self.webView = webView
+		self.webView.opaque = false
+		self.webView.backgroundColor = UIColor.clearColor()
 		self.eventListener = eventListener
 		// The video element view.
 		self.elementView = UIView()
@@ -27,12 +29,9 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 		// It's placed over the elementView.
 		self.videoView = RTCEAGLVideoView()
 
-		self.webView.addSubview(self.elementView)
-		self.webView.bringSubviewToFront(self.elementView)
-
 		self.elementView.userInteractionEnabled = false
 		self.elementView.hidden = true
-		self.elementView.backgroundColor = UIColor.blackColor()
+		self.elementView.backgroundColor = UIColor.clearColor()
 		self.elementView.addSubview(self.videoView)
 		self.elementView.layer.masksToBounds = true
 
@@ -178,7 +177,19 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 		}
 
 		self.elementView.alpha = CGFloat(opacity)
-		self.elementView.layer.zPosition = CGFloat(zIndex)
+		self.elementView.tag = Int(zIndex)
+
+		var prevSiblingView: UIView?
+		for childView in (self.webView.superview?.subviews)!{
+			if(childView.tag > Int(zIndex)) {
+		    prevSiblingView = childView;
+		    break;
+		  }
+		}
+
+		if let view = prevSiblingView {
+			self.webView.superview?.insertSubview(self.elementView, belowSubview: view)
+		}
 
 		if !mirrored {
 			self.elementView.transform = CGAffineTransformIdentity


### PR DESCRIPTION
This fix allows for:
1. HTML View present above all video UI Views
2. Video UI views stacked according to z-index
3. Webhook now fixes MainViewController.m to allow for transparent background on webView

NOTE: `video::-webkit-media-controls { display:none !important; }` must be added to the CSS to hide video controllers, maybe this should be added to the documentation. 