### PR TITLE
Bugfix _iosrtcVideoHandled flag when removing node

### DIFF
--- a/dist/cordova-plugin-iosrtc.js
+++ b/dist/cordova-plugin-iosrtc.js
@@ -2436,6 +2436,7 @@ var debug = require('debug')('iosrtc:videoElementsHandler'),
 
 				// If this video element was previously handling a MediaStreamRenderer, release it.
 				releaseMediaStreamRenderer(node);
+				delete node._iosrtcVideoHandled;
 			} else {
 				for (j = 0; j < node.childNodes.length; j++) {
 					childNode = node.childNodes.item(j);

--- a/js/videoElementsHandler.js
+++ b/js/videoElementsHandler.js
@@ -114,6 +114,7 @@ var debug = require('debug')('iosrtc:videoElementsHandler'),
 
 				// If this video element was previously handling a MediaStreamRenderer, release it.
 				releaseMediaStreamRenderer(node);
+				delete node._iosrtcVideoHandled;
 			} else {
 				for (j = 0; j < node.childNodes.length; j++) {
 					childNode = node.childNodes.item(j);


### PR DESCRIPTION
This bug was being triggered if you removed the video element from the DOM and try to add it later.