### PR TITLE
WebSocket hack loads iff iOS Cordova

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,12 @@ If you are using the plugin we would love to [heard back from you](WHO_USES_IT.m
 
 Don't call plugin methods within WebSocket events (`onopen`, `onmessage`, etc). There is an issue in iOS Safari (see [issue #12](https://github.com/eface2face/cordova-plugin-iosrtc/issues/12)). Instead run a `setTimeout()` within the WebSocket event if you need to call plugin methods on it.
 
-Or better, just load the provided [ios-websocket-hack.js](extra/ios-websocket-hack.js) script into your Cordova iOS app and you are done.
+Or better yet, include the provided [ios-websocket-hack.js](extra/ios-websocket-hack.js) in your app and load into your `index.html` as follows:
 
+```
+<script src="cordova.js"></script>
+<script src="ios-websocket-hack.min.js"></script>
+```
 
 #### HTML5 video API
 

--- a/extra/ios-websocket-hack.js
+++ b/extra/ios-websocket-hack.js
@@ -17,6 +17,9 @@
 
 
 (function () {
+    // run on iOS Cordova only
+    if (!(window.cordova && window.cordova.platformId === 'ios')) return;
+
 	// Store a reference of the native WebSocket class.
 	var NativeWebSocket = window.WebSocket;
 

--- a/extra/ios-websocket-hack.js
+++ b/extra/ios-websocket-hack.js
@@ -17,8 +17,8 @@
 
 
 (function () {
-    // run on iOS Cordova only
-    if (!(window.cordova && window.cordova.platformId === 'ios')) return;
+	// run on iOS Cordova only
+	if (!(window.cordova && window.cordova.platformId === 'ios')) return;
 
 	// Store a reference of the native WebSocket class.
 	var NativeWebSocket = window.WebSocket;


### PR DESCRIPTION
There's no easy way to for us to have conditional `<script>` tags for each individual platform in our `index.html`. The easiest way seems to be just to have conditional execution right in the `ios-websocket-hack.js` file itself. This way, all platforms can load the same script but only iOS Cordova will have this WS hack enabled.