### PR TITLE
force track to enabled = false after calling track.stop()

### DIFF
--- a/dist/cordova-plugin-iosrtc.js
+++ b/dist/cordova-plugin-iosrtc.js
@@ -1,5 +1,5 @@
 /*
- * cordova-plugin-iosrtc v2.2.3
+ * cordova-plugin-iosrtc v2.2.4-pre
  * Cordova iOS plugin exposing the full WebRTC W3C JavaScript APIs
  * Copyright 2015-2016 Iñaki Baz Castillo at eFace2Face, inc. (https://eface2face.com)
  * License MIT
@@ -307,12 +307,14 @@ MediaStream.prototype.stop = function () {
 	for (trackId in this._audioTracks) {
 		if (this._audioTracks.hasOwnProperty(trackId)) {
 			this._audioTracks[trackId].stop();
+			this._audioTracks[trackId].enabled = false;
 		}
 	}
 
 	for (trackId in this._videoTracks) {
 		if (this._videoTracks.hasOwnProperty(trackId)) {
 			this._videoTracks[trackId].stop();
+			this._videoTracks[trackId].enabled = false;
 		}
 	}
 };
@@ -2286,7 +2288,7 @@ function dump() {
 }
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./MediaStream":3,"./MediaStreamTrack":5,"./RTCIceCandidate":7,"./RTCPeerConnection":8,"./RTCSessionDescription":9,"./enumerateDevices":10,"./getUserMedia":11,"./rtcninjaPlugin":13,"./videoElementsHandler":14,"cordova/exec":undefined,"debug":15,"domready":18}],13:[function(require,module,exports){
+},{"./MediaStream":3,"./MediaStreamTrack":5,"./RTCIceCandidate":7,"./RTCPeerConnection":8,"./RTCSessionDescription":9,"./enumerateDevices":10,"./getUserMedia":11,"./rtcninjaPlugin":13,"./videoElementsHandler":14,"cordova/exec":undefined,"debug":15,"domready":17}],13:[function(require,module,exports){
 /**
  * Expose the rtcninjaPlugin object.
  */
@@ -3025,7 +3027,39 @@ function coerce(val) {
   return val;
 }
 
-},{"ms":17}],17:[function(require,module,exports){
+},{"ms":18}],17:[function(require,module,exports){
+/*!
+  * domready (c) Dustin Diaz 2014 - License MIT
+  */
+!function (name, definition) {
+
+  if (typeof module != 'undefined') module.exports = definition()
+  else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
+  else this[name] = definition()
+
+}('domready', function () {
+
+  var fns = [], listener
+    , doc = document
+    , hack = doc.documentElement.doScroll
+    , domContentLoaded = 'DOMContentLoaded'
+    , loaded = (hack ? /^loaded|^c/ : /^loaded|^i|^c/).test(doc.readyState)
+
+
+  if (!loaded)
+  doc.addEventListener(domContentLoaded, listener = function () {
+    doc.removeEventListener(domContentLoaded, listener)
+    loaded = 1
+    while (listener = fns.shift()) listener()
+  })
+
+  return function (fn) {
+    loaded ? setTimeout(fn, 0) : fns.push(fn)
+  }
+
+});
+
+},{}],18:[function(require,module,exports){
 /**
  * Helpers.
  */
@@ -3151,38 +3185,6 @@ function plural(ms, n, name) {
   if (ms < n * 1.5) return Math.floor(ms / n) + ' ' + name;
   return Math.ceil(ms / n) + ' ' + name + 's';
 }
-
-},{}],18:[function(require,module,exports){
-/*!
-  * domready (c) Dustin Diaz 2014 - License MIT
-  */
-!function (name, definition) {
-
-  if (typeof module != 'undefined') module.exports = definition()
-  else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
-  else this[name] = definition()
-
-}('domready', function () {
-
-  var fns = [], listener
-    , doc = document
-    , hack = doc.documentElement.doScroll
-    , domContentLoaded = 'DOMContentLoaded'
-    , loaded = (hack ? /^loaded|^c/ : /^loaded|^i|^c/).test(doc.readyState)
-
-
-  if (!loaded)
-  doc.addEventListener(domContentLoaded, listener = function () {
-    doc.removeEventListener(domContentLoaded, listener)
-    loaded = 1
-    while (listener = fns.shift()) listener()
-  })
-
-  return function (fn) {
-    loaded ? setTimeout(fn, 0) : fns.push(fn)
-  }
-
-});
 
 },{}],19:[function(require,module,exports){
 void function(root){

--- a/js/MediaStream.js
+++ b/js/MediaStream.js
@@ -221,12 +221,14 @@ MediaStream.prototype.stop = function () {
 	for (trackId in this._audioTracks) {
 		if (this._audioTracks.hasOwnProperty(trackId)) {
 			this._audioTracks[trackId].stop();
+			this._audioTracks[trackId].enabled = false;
 		}
 	}
 
 	for (trackId in this._videoTracks) {
 		if (this._videoTracks.hasOwnProperty(trackId)) {
 			this._videoTracks[trackId].stop();
+			this._videoTracks[trackId].enabled = false;
 		}
 	}
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp-jscs": "^3.0.2",
     "gulp-jscs-stylish": "^1.3.0",
     "gulp-jshint": "^2.0.0",
+    "jshint": "^2.9.1",
     "jshint-stylish": "~2.1.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-iosrtc",
-  "version": "2.2.4-pre",
+  "version": "2.2.5",
   "description": "Cordova iOS plugin exposing the full WebRTC W3C JavaScript APIs",
   "author": "Iñaki Baz Castillo at eFace2Face, inc. (https://eface2face.com)",
   "license": "MIT",


### PR DESCRIPTION
Hi,
calling `stop()` on `MediaTrack` still remains active.
No problem in firefox and chrome with same implementation.

The solution is to force track to enabled = false after calling track.stop() .