### PR TITLE
Closing PeerConnection that causes iOS app keep running background mode after ending calls

### DIFF
--- a/src/PluginRTCPeerConnection.swift
+++ b/src/PluginRTCPeerConnection.swift
@@ -463,6 +463,10 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate, RTCSessionD
 
 		NSLog("PluginRTCPeerConnection | oniceconnectionstatechange [iceConnectionState:\(state_str)]")
 
+		if state_str == "disconnected" {
+			self.close()
+		}
+
 		self.eventListener(data: [
 			"type": "iceconnectionstatechange",
 			"iceConnectionState": state_str


### PR DESCRIPTION
Fixing the problem on iOS that keep PeerConnection on even when app is not active. This keep audio background mode running on iOS