### PR TITLE
Use closure syntax for weak and unowned vars.

### DIFF
--- a/src/PluginRTCPeerConnection.swift
+++ b/src/PluginRTCPeerConnection.swift
@@ -137,7 +137,7 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate, RTCSessionD
 		let sdp = desc.objectForKey("sdp") as? String ?? ""
 		let rtcSessionDescription = RTCSessionDescription(type: type, sdp: sdp)
 
-		self.onSetDescriptionSuccessCallback = { () -> Void in
+		self.onSetDescriptionSuccessCallback = { [unowned self] () -> Void in
 			NSLog("PluginRTCPeerConnection#setLocalDescription() | success callback")
 
 			let data = [
@@ -175,7 +175,7 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate, RTCSessionD
 		let sdp = desc.objectForKey("sdp") as? String ?? ""
 		let rtcSessionDescription = RTCSessionDescription(type: type, sdp: sdp)
 
-		self.onSetDescriptionSuccessCallback = { () -> Void in
+		self.onSetDescriptionSuccessCallback = { [unowned self] () -> Void in
 			NSLog("PluginRTCPeerConnection#setRemoteDescription() | success callback")
 
 			let data = [
@@ -300,7 +300,7 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate, RTCSessionD
 	) {
 		NSLog("PluginRTCPeerConnection#RTCDataChannel_setListener()")
 
-		weak var pluginRTCDataChannel = self.pluginRTCDataChannels[dcId]
+		let pluginRTCDataChannel = self.pluginRTCDataChannels[dcId]
 
 		if pluginRTCDataChannel == nil {
 			return;
@@ -335,7 +335,7 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate, RTCSessionD
 			return
 		}
 
-		weak var pluginRTCDataChannel = self.pluginRTCDataChannels[dcId]
+		let pluginRTCDataChannel = self.pluginRTCDataChannels[dcId]
 
 		if pluginRTCDataChannel == nil {
 			return;
@@ -356,7 +356,7 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate, RTCSessionD
 			return
 		}
 
-		weak var pluginRTCDataChannel = self.pluginRTCDataChannels[dcId]
+		let pluginRTCDataChannel = self.pluginRTCDataChannels[dcId]
 
 		if pluginRTCDataChannel == nil {
 			return;
@@ -373,7 +373,7 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate, RTCSessionD
 			return
 		}
 
-		weak var pluginRTCDataChannel = self.pluginRTCDataChannels[dcId]
+		let pluginRTCDataChannel = self.pluginRTCDataChannels[dcId]
 
 		if pluginRTCDataChannel == nil {
 			return;

--- a/src/iosrtcPlugin.swift
+++ b/src/iosrtcPlugin.swift
@@ -95,15 +95,15 @@ class iosrtcPlugin : CDVPlugin {
 			options = command.argumentAtIndex(1) as? NSDictionary
 		}
 
-		weak var pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
+		let pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
 
 		if pluginRTCPeerConnection == nil {
 			NSLog("iosrtcPlugin#RTCPeerConnection_createOffer() | ERROR: pluginRTCPeerConnection with pcId=\(pcId) does not exist")
 			return;
 		}
 
-		dispatch_async(self.queue) {
-			pluginRTCPeerConnection!.createOffer(options,
+		dispatch_async(self.queue) { [weak pluginRTCPeerConnection] in
+			pluginRTCPeerConnection?.createOffer(options,
 				callback: { (data: NSDictionary) -> Void in
 					self.emit(command.callbackId,
 						result: CDVPluginResult(status: CDVCommandStatus_OK, messageAsDictionary: data as [NSObject : AnyObject])
@@ -129,15 +129,15 @@ class iosrtcPlugin : CDVPlugin {
 			options = command.argumentAtIndex(1) as? NSDictionary
 		}
 
-		weak var pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
+		let pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
 
 		if pluginRTCPeerConnection == nil {
 			NSLog("iosrtcPlugin#RTCPeerConnection_createAnswer() | ERROR: pluginRTCPeerConnection with pcId=\(pcId) does not exist")
 			return;
 		}
 
-		dispatch_async(self.queue) {
-			pluginRTCPeerConnection!.createAnswer(options,
+		dispatch_async(self.queue) { [weak pluginRTCPeerConnection] in
+			pluginRTCPeerConnection?.createAnswer(options,
 				callback: { (data: NSDictionary) -> Void in
 					self.emit(command.callbackId,
 						result: CDVPluginResult(status: CDVCommandStatus_OK, messageAsDictionary: data as [NSObject : AnyObject])
@@ -158,15 +158,15 @@ class iosrtcPlugin : CDVPlugin {
 
 		let pcId = command.argumentAtIndex(0) as! Int
 		let desc = command.argumentAtIndex(1) as! NSDictionary
-		weak var pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
+		let pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
 
 		if pluginRTCPeerConnection == nil {
 			NSLog("iosrtcPlugin#RTCPeerConnection_setLocalDescription() | ERROR: pluginRTCPeerConnection with pcId=\(pcId) does not exist")
 			return;
 		}
 
-		dispatch_async(self.queue) {
-			pluginRTCPeerConnection!.setLocalDescription(desc,
+		dispatch_async(self.queue) { [weak pluginRTCPeerConnection] in
+			pluginRTCPeerConnection?.setLocalDescription(desc,
 				callback: { (data: NSDictionary) -> Void in
 					self.emit(command.callbackId,
 						result: CDVPluginResult(status: CDVCommandStatus_OK, messageAsDictionary: data as [NSObject : AnyObject])
@@ -187,15 +187,15 @@ class iosrtcPlugin : CDVPlugin {
 
 		let pcId = command.argumentAtIndex(0) as! Int
 		let desc = command.argumentAtIndex(1) as! NSDictionary
-		weak var pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
+		let pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
 
 		if pluginRTCPeerConnection == nil {
 			NSLog("iosrtcPlugin#RTCPeerConnection_setRemoteDescription() | ERROR: pluginRTCPeerConnection with pcId=\(pcId) does not exist")
 			return;
 		}
 
-		dispatch_async(self.queue) {
-			pluginRTCPeerConnection!.setRemoteDescription(desc,
+		dispatch_async(self.queue) { [weak pluginRTCPeerConnection] in
+			pluginRTCPeerConnection?.setRemoteDescription(desc,
 				callback: { (data: NSDictionary) -> Void in
 					self.emit(command.callbackId,
 						result: CDVPluginResult(status: CDVCommandStatus_OK, messageAsDictionary: data as [NSObject : AnyObject])
@@ -216,15 +216,15 @@ class iosrtcPlugin : CDVPlugin {
 
 		let pcId = command.argumentAtIndex(0) as! Int
 		let candidate = command.argumentAtIndex(1) as! NSDictionary
-		weak var pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
+		let pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
 
 		if pluginRTCPeerConnection == nil {
 			NSLog("iosrtcPlugin#RTCPeerConnection_addIceCandidate() | ERROR: pluginRTCPeerConnection with pcId=\(pcId) does not exist")
 			return;
 		}
 
-		dispatch_async(self.queue) {
-			pluginRTCPeerConnection!.addIceCandidate(candidate,
+		dispatch_async(self.queue) { [weak pluginRTCPeerConnection] in
+			pluginRTCPeerConnection?.addIceCandidate(candidate,
 				callback: { (data: NSDictionary) -> Void in
 					self.emit(command.callbackId,
 						result: CDVPluginResult(status: CDVCommandStatus_OK, messageAsDictionary: data as [NSObject : AnyObject])
@@ -245,8 +245,8 @@ class iosrtcPlugin : CDVPlugin {
 
 		let pcId = command.argumentAtIndex(0) as! Int
 		let streamId = command.argumentAtIndex(1) as! String
-		weak var pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
-		weak var pluginMediaStream = self.pluginMediaStreams[streamId]
+		let pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
+		let pluginMediaStream = self.pluginMediaStreams[streamId]
 
 		if pluginRTCPeerConnection == nil {
 			NSLog("iosrtcPlugin#RTCPeerConnection_addStream() | ERROR: pluginRTCPeerConnection with pcId=\(pcId) does not exist")
@@ -258,8 +258,8 @@ class iosrtcPlugin : CDVPlugin {
 			return;
 		}
 
-		dispatch_async(self.queue) {
-			if pluginRTCPeerConnection!.addStream(pluginMediaStream!) {
+		dispatch_async(self.queue) { [weak pluginRTCPeerConnection, weak pluginMediaStream] in
+			if pluginRTCPeerConnection?.addStream(pluginMediaStream!) == true {
 				self.saveMediaStream(pluginMediaStream!)
 			}
 		}
@@ -271,8 +271,8 @@ class iosrtcPlugin : CDVPlugin {
 
 		let pcId = command.argumentAtIndex(0) as! Int
 		let streamId = command.argumentAtIndex(1) as! String
-		weak var pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
-		weak var pluginMediaStream = self.pluginMediaStreams[streamId]
+		let pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
+		let pluginMediaStream = self.pluginMediaStreams[streamId]
 
 		if pluginRTCPeerConnection == nil {
 			NSLog("iosrtcPlugin#RTCPeerConnection_removeStream() | pluginRTCPeerConnection with pcId=\(pcId) does not exist")
@@ -284,8 +284,8 @@ class iosrtcPlugin : CDVPlugin {
 			return;
 		}
 
-		dispatch_async(self.queue) {
-			pluginRTCPeerConnection!.removeStream(pluginMediaStream!)
+		dispatch_async(self.queue) { [weak pluginRTCPeerConnection, weak pluginMediaStream] in
+			pluginRTCPeerConnection?.removeStream(pluginMediaStream!)
 		}
 	}
 
@@ -302,15 +302,15 @@ class iosrtcPlugin : CDVPlugin {
 			options = command.argumentAtIndex(3) as? NSDictionary
 		}
 
-		weak var pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
+		let pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
 
 		if pluginRTCPeerConnection == nil {
 			NSLog("iosrtcPlugin#RTCPeerConnection_createDataChannel() | ERROR: pluginRTCPeerConnection with pcId=\(pcId) does not exist")
 			return;
 		}
 
-		dispatch_async(self.queue) {
-			pluginRTCPeerConnection!.createDataChannel(dcId,
+		dispatch_async(self.queue) { [weak pluginRTCPeerConnection] in
+			pluginRTCPeerConnection?.createDataChannel(dcId,
 				label: label,
 				options: options,
 				eventListener: { (data: NSDictionary) -> Void in
@@ -357,15 +357,15 @@ class iosrtcPlugin : CDVPlugin {
 
 		let pcId = command.argumentAtIndex(0) as! Int
 		let dcId = command.argumentAtIndex(1) as! Int
-		weak var pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
+		let pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
 
 		if pluginRTCPeerConnection == nil {
 			NSLog("iosrtcPlugin#RTCPeerConnection_RTCDataChannel_setListener() | ERROR: pluginRTCPeerConnection with pcId=\(pcId) does not exist")
 			return;
 		}
 
-		dispatch_async(self.queue) {
-			pluginRTCPeerConnection!.RTCDataChannel_setListener(dcId,
+		dispatch_async(self.queue) { [weak pluginRTCPeerConnection] in
+			pluginRTCPeerConnection?.RTCDataChannel_setListener(dcId,
 				eventListener: { (data: NSDictionary) -> Void in
 					let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAsDictionary: data as [NSObject : AnyObject])
 
@@ -391,15 +391,15 @@ class iosrtcPlugin : CDVPlugin {
 		let pcId = command.argumentAtIndex(0) as! Int
 		let dcId = command.argumentAtIndex(1) as! Int
 		let data = command.argumentAtIndex(2) as! String
-		weak var pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
+		let pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
 
 		if pluginRTCPeerConnection == nil {
 			NSLog("iosrtcPlugin#RTCPeerConnection_RTCDataChannel_sendString() | ERROR: pluginRTCPeerConnection with pcId=\(pcId) does not exist")
 			return;
 		}
 
-		dispatch_async(self.queue) {
-			pluginRTCPeerConnection!.RTCDataChannel_sendString(dcId,
+		dispatch_async(self.queue) { [weak pluginRTCPeerConnection] in
+			pluginRTCPeerConnection?.RTCDataChannel_sendString(dcId,
 				data: data,
 				callback: { (data: NSDictionary) -> Void in
 					self.emit(command.callbackId,
@@ -417,15 +417,15 @@ class iosrtcPlugin : CDVPlugin {
 		let pcId = command.argumentAtIndex(0) as! Int
 		let dcId = command.argumentAtIndex(1) as! Int
 		let data = command.argumentAtIndex(2) as! NSData
-		weak var pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
+		let pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
 
 		if pluginRTCPeerConnection == nil {
 			NSLog("iosrtcPlugin#RTCPeerConnection_RTCDataChannel_sendBinary() | ERROR: pluginRTCPeerConnection with pcId=\(pcId) does not exist")
 			return;
 		}
 
-		dispatch_async(self.queue) {
-			pluginRTCPeerConnection!.RTCDataChannel_sendBinary(dcId,
+		dispatch_async(self.queue) { [weak pluginRTCPeerConnection] in
+			pluginRTCPeerConnection?.RTCDataChannel_sendBinary(dcId,
 				data: data,
 				callback: { (data: NSDictionary) -> Void in
 					self.emit(command.callbackId,
@@ -442,15 +442,15 @@ class iosrtcPlugin : CDVPlugin {
 
 		let pcId = command.argumentAtIndex(0) as! Int
 		let dcId = command.argumentAtIndex(1) as! Int
-		weak var pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
+		let pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
 
 		if pluginRTCPeerConnection == nil {
 			NSLog("iosrtcPlugin#RTCPeerConnection_RTCDataChannel_close() | ERROR: pluginRTCPeerConnection with pcId=\(pcId) does not exist")
 			return;
 		}
 
-		dispatch_async(self.queue) {
-			pluginRTCPeerConnection!.RTCDataChannel_close(dcId)
+		dispatch_async(self.queue) { [weak pluginRTCPeerConnection] in
+			pluginRTCPeerConnection?.RTCDataChannel_close(dcId)
 		}
 	}
 
@@ -459,16 +459,16 @@ class iosrtcPlugin : CDVPlugin {
 		NSLog("iosrtcPlugin#MediaStream_setListener()")
 
 		let id = command.argumentAtIndex(0) as! String
-		weak var pluginMediaStream = self.pluginMediaStreams[id]
+		let pluginMediaStream = self.pluginMediaStreams[id]
 
 		if pluginMediaStream == nil {
 			NSLog("iosrtcPlugin#MediaStream_setListener() | ERROR: pluginMediaStream with id=\(id) does not exist")
 			return;
 		}
 
-		dispatch_async(self.queue) {
+		dispatch_async(self.queue) { [weak pluginMediaStream] in
 			// Set the eventListener.
-			pluginMediaStream!.setListener(
+			pluginMediaStream?.setListener(
 				{ (data: NSDictionary) -> Void in
 					let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAsDictionary: data as [NSObject : AnyObject])
 
@@ -488,8 +488,8 @@ class iosrtcPlugin : CDVPlugin {
 
 		let id = command.argumentAtIndex(0) as! String
 		let trackId = command.argumentAtIndex(1) as! String
-		weak var pluginMediaStream = self.pluginMediaStreams[id]
-		weak var pluginMediaStreamTrack = self.pluginMediaStreamTracks[trackId]
+		let pluginMediaStream = self.pluginMediaStreams[id]
+		let pluginMediaStreamTrack = self.pluginMediaStreamTracks[trackId]
 
 		if pluginMediaStream == nil {
 			NSLog("iosrtcPlugin#MediaStream_addTrack() | ERROR: pluginMediaStream with id=\(id) does not exist")
@@ -501,8 +501,8 @@ class iosrtcPlugin : CDVPlugin {
 			return;
 		}
 
-		dispatch_async(self.queue) {
-			pluginMediaStream!.addTrack(pluginMediaStreamTrack!)
+		dispatch_async(self.queue) { [weak pluginMediaStream, weak pluginMediaStreamTrack] in
+			pluginMediaStream?.addTrack(pluginMediaStreamTrack!)
 		}
 	}
 
@@ -512,8 +512,8 @@ class iosrtcPlugin : CDVPlugin {
 
 		let id = command.argumentAtIndex(0) as! String
 		let trackId = command.argumentAtIndex(1) as! String
-		weak var pluginMediaStream = self.pluginMediaStreams[id]
-		weak var pluginMediaStreamTrack = self.pluginMediaStreamTracks[trackId]
+		let pluginMediaStream = self.pluginMediaStreams[id]
+		let pluginMediaStreamTrack = self.pluginMediaStreamTracks[trackId]
 
 		if pluginMediaStream == nil {
 			NSLog("iosrtcPlugin#MediaStream_removeTrack() | ERROR: pluginMediaStream with id=\(id) does not exist")
@@ -525,8 +525,8 @@ class iosrtcPlugin : CDVPlugin {
 			return;
 		}
 
-		dispatch_async(self.queue) {
-			pluginMediaStream!.removeTrack(pluginMediaStreamTrack!)
+		dispatch_async(self.queue) { [weak pluginMediaStream, weak pluginMediaStreamTrack] in
+			pluginMediaStream?.removeTrack(pluginMediaStreamTrack!)
 		}
 	}
 
@@ -535,7 +535,7 @@ class iosrtcPlugin : CDVPlugin {
 		NSLog("iosrtcPlugin#MediaStream_release()")
 
 		let id = command.argumentAtIndex(0) as! String
-		weak var pluginMediaStream = self.pluginMediaStreams[id]
+		let pluginMediaStream = self.pluginMediaStreams[id]
 
 		if pluginMediaStream == nil {
 			NSLog("iosrtcPlugin#MediaStream_release() | ERROR: pluginMediaStream with id=\(id) does not exist")
@@ -550,16 +550,16 @@ class iosrtcPlugin : CDVPlugin {
 		NSLog("iosrtcPlugin#MediaStreamTrack_setListener()")
 
 		let id = command.argumentAtIndex(0) as! String
-		weak var pluginMediaStreamTrack = self.pluginMediaStreamTracks[id]
+		let pluginMediaStreamTrack = self.pluginMediaStreamTracks[id]
 
 		if pluginMediaStreamTrack == nil {
 			NSLog("iosrtcPlugin#MediaStreamTrack_setListener() | ERROR: pluginMediaStreamTrack with id=\(id) does not exist")
 			return;
 		}
 
-		dispatch_async(self.queue) {
+		dispatch_async(self.queue) { [weak pluginMediaStreamTrack] in
 			// Set the eventListener.
-			pluginMediaStreamTrack!.setListener(
+			pluginMediaStreamTrack?.setListener(
 				{ (data: NSDictionary) -> Void in
 					let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAsDictionary: data as [NSObject : AnyObject])
 
@@ -581,15 +581,15 @@ class iosrtcPlugin : CDVPlugin {
 
 		let id = command.argumentAtIndex(0) as! String
 		let value = command.argumentAtIndex(1) as! Bool
-		weak var pluginMediaStreamTrack = self.pluginMediaStreamTracks[id]
+		let pluginMediaStreamTrack = self.pluginMediaStreamTracks[id]
 
 		if pluginMediaStreamTrack == nil {
 			NSLog("iosrtcPlugin#MediaStreamTrack_setEnabled() | ERROR: pluginMediaStreamTrack with id=\(id) does not exist")
 			return;
 		}
 
-		dispatch_async(self.queue) {
-			pluginMediaStreamTrack!.setEnabled(value)
+		dispatch_async(self.queue) {[weak pluginMediaStreamTrack] in
+			pluginMediaStreamTrack?.setEnabled(value)
 		}
 	}
 
@@ -605,8 +605,8 @@ class iosrtcPlugin : CDVPlugin {
 			return;
 		}
 
-		dispatch_async(self.queue) {
-			pluginMediaStreamTrack!.stop()
+		dispatch_async(self.queue) { [weak pluginMediaStreamTrack] in
+			pluginMediaStreamTrack?.stop()
 		}
 	}
 
@@ -640,8 +640,8 @@ class iosrtcPlugin : CDVPlugin {
 
 		let id = command.argumentAtIndex(0) as! Int
 		let streamId = command.argumentAtIndex(1) as! String
-		weak var pluginMediaStreamRenderer = self.pluginMediaStreamRenderers[id]
-		weak var pluginMediaStream = self.pluginMediaStreams[streamId]
+		let pluginMediaStreamRenderer = self.pluginMediaStreamRenderers[id]
+		let pluginMediaStream = self.pluginMediaStreams[streamId]
 
 		if pluginMediaStreamRenderer == nil {
 			NSLog("iosrtcPlugin#MediaStreamRenderer_render() | ERROR: pluginMediaStreamRenderer with id=\(id) does not exist")
@@ -661,7 +661,7 @@ class iosrtcPlugin : CDVPlugin {
 		NSLog("iosrtcPlugin#MediaStreamRenderer_mediaStreamChanged()")
 
 		let id = command.argumentAtIndex(0) as! Int
-		weak var pluginMediaStreamRenderer = self.pluginMediaStreamRenderers[id]
+		let pluginMediaStreamRenderer = self.pluginMediaStreamRenderers[id]
 
 		if pluginMediaStreamRenderer == nil {
 			NSLog("iosrtcPlugin#MediaStreamRenderer_mediaStreamChanged() | ERROR: pluginMediaStreamRenderer with id=\(id) does not exist")
@@ -677,7 +677,7 @@ class iosrtcPlugin : CDVPlugin {
 
 		let id = command.argumentAtIndex(0) as! Int
 		let data = command.argumentAtIndex(1) as! NSDictionary
-		weak var pluginMediaStreamRenderer = self.pluginMediaStreamRenderers[id]
+		let pluginMediaStreamRenderer = self.pluginMediaStreamRenderers[id]
 
 		if pluginMediaStreamRenderer == nil {
 			NSLog("iosrtcPlugin#MediaStreamRenderer_refresh() | ERROR: pluginMediaStreamRenderer with id=\(id) does not exist")


### PR DESCRIPTION
This PR uses closure syntax to define the weak/unowned variables or self, and fixes strong reference loop bugs in setLocalDescription and setRemoteDescription.
Without this fix, calling RTCPeerConnection.close() on javascript will not correctly deallocate all underlying native objects.