### PR TITLE
#161: Crash in RTCPeerConnection.close()

### DIFF
--- a/src/iosrtcPlugin.swift
+++ b/src/iosrtcPlugin.swift
@@ -354,7 +354,9 @@ class iosrtcPlugin : CDVPlugin {
 		}
 
 		dispatch_async(self.queue) { [weak pluginRTCPeerConnection] in
-			pluginRTCPeerConnection!.close()
+		    if pluginRTCPeerConnection != nil {
+			    pluginRTCPeerConnection!.close()
+			}
 
 			// Remove the pluginRTCPeerConnection from the dictionary.
 			self.pluginRTCPeerConnections[pcId] = nil

--- a/src/iosrtcPlugin.swift
+++ b/src/iosrtcPlugin.swift
@@ -354,9 +354,9 @@ class iosrtcPlugin : CDVPlugin {
 		}
 
 		dispatch_async(self.queue) { [weak pluginRTCPeerConnection] in
-		    if pluginRTCPeerConnection != nil {
-			    pluginRTCPeerConnection!.close()
-			}
+            if pluginRTCPeerConnection != nil {
+                pluginRTCPeerConnection!.close()
+            }
 
 			// Remove the pluginRTCPeerConnection from the dictionary.
 			self.pluginRTCPeerConnections[pcId] = nil


### PR DESCRIPTION
Fixes crash when calling close() twice