### PR TITLE
Changed faulty "this" to "self" in getStats callback

### DIFF
--- a/dist/cordova-plugin-iosrtc.js
+++ b/dist/cordova-plugin-iosrtc.js
@@ -1964,7 +1964,7 @@ RTCPeerConnection.prototype.getStats = function () {
 				reject(new global.DOMError(error));
 			}
 
-			exec(onResultOK, onResultError, 'iosrtcPlugin', 'RTCPeerConnection_getStats', [this.pcId, selector ? selector.id : null]);
+			exec(onResultOK, onResultError, 'iosrtcPlugin', 'RTCPeerConnection_getStats', [self.pcId, selector ? selector.id : null]);
 		});
 	}
 

--- a/js/RTCPeerConnection.js
+++ b/js/RTCPeerConnection.js
@@ -648,7 +648,7 @@ RTCPeerConnection.prototype.getStats = function () {
 				reject(new global.DOMError(error));
 			}
 
-			exec(onResultOK, onResultError, 'iosrtcPlugin', 'RTCPeerConnection_getStats', [this.pcId, selector ? selector.id : null]);
+			exec(onResultOK, onResultError, 'iosrtcPlugin', 'RTCPeerConnection_getStats', [self.pcId, selector ? selector.id : null]);
 		});
 	}
 


### PR DESCRIPTION
Replaced faulty this with self in the promise implementation of RTCPeerConnection.getStats.