### PR TITLE
Add srcObject for media stream

### DIFF
--- a/dist/cordova-plugin-iosrtc.js
+++ b/dist/cordova-plugin-iosrtc.js
@@ -2591,6 +2591,7 @@ module.exports = {
 
 function attachMediaStream(element, stream) {
 	element.src = URL.createObjectURL(stream);
+	element.srcObject = stream;
 	return element;
 }
 

--- a/dist/cordova-plugin-iosrtc.js
+++ b/dist/cordova-plugin-iosrtc.js
@@ -2591,7 +2591,6 @@ module.exports = {
 
 function attachMediaStream(element, stream) {
 	element.src = URL.createObjectURL(stream);
-	element.srcObject = stream;
 	return element;
 }
 

--- a/js/rtcninjaPlugin.js
+++ b/js/rtcninjaPlugin.js
@@ -26,5 +26,6 @@ module.exports = {
 
 function attachMediaStream(element, stream) {
 	element.src = URL.createObjectURL(stream);
+	element.srcObject = stream;
 	return element;
 }


### PR DESCRIPTION
Using videoObject.src is no longer part of the standard and was replaced by srcObject for a number of reasons
see more: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/srcObject